### PR TITLE
removed importlib as explicit dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -562,14 +562,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
-name = "importlib"
-version = "1.0.4"
-description = "Backport of importlib.import_module() from Python 2.7"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ matplotlib = "^3.5.2"
 h5py = "^3.6.0"
 nptyping = "^2.0.1"
 nose = "^1.3.7"
-importlib = "^1.0.4"
 
 [tool.poetry.scripts]
 hysr_pam_install = 'hysr_install.pam_install:run'


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

During performing installation on a new computer, pip failed to install importlib with error:

```'NO Module named importlib.util```

Apparently, importlib is builtin:

https://stackoverflow.com/questions/48776853/what-is-importlib-util-in-python3

I am confused because I never had this issue on other machines.

For now, removing importlib as explicit dependency.



## How I Tested

The (pip) installation worked after removing importlib

