### PR TITLE
Vberenz/nptyping

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -562,14 +562,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
-name = "importlib"
-version = "1.0.4"
-description = "Backport of importlib.import_module() from Python 2.7"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ matplotlib = "^3.5.2"
 h5py = "^3.6.0"
 nptyping = "^2.0.1"
 nose = "^1.3.7"
-importlib = "^1.0.4"
 
 [tool.poetry.scripts]
 hysr_pam_install = 'hysr_install.pam_install:run'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ Sphinx = "^4.5.0"
 breathe = "^4.33.1"
 matplotlib = "^3.5.2"
 h5py = "^3.6.0"
-nptyping = "^2.0.1"
+nptyping = "2.0.1"
 nose = "^1.3.7"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

The newest version of nptyping breaks pam_mujoco. It is annoying, because it is the second time in a couple of months that updates do not maintain retro-compatibility. 

I will update the code to support the latest version nptyping (or better, to stop using nptyping), but in the meantime forcing nptyping to be at the version 2.0.1
 
## How I Tested

Uninstalled version 2.1.1 and installing 2.0.1 instead

